### PR TITLE
Fix Anaconda to the Python 3.9 version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,7 +60,7 @@ Most Linux distributions come with a text editor installed. You may also
 
 ### Installing with conda
 
-1. Download and install the [Python **3.7** **64-bit** version of Miniconda](https://conda.io/en/latest/miniconda.html).
+1. Download and install the [Python **3.9** **64-bit** version of Miniconda](https://conda.io/en/latest/miniconda.html).
    This will give you access to the conda package manager. **Make sure you select to
    have conda added to your `PATH` when asked by the installer**. If you have
    the Anaconda Python distribution installed, you won't need to do this step.
@@ -76,7 +76,7 @@ Most Linux distributions come with a text editor installed. You may also
 There are 4 options for installing GMT 6.2.0 under macOS:
 
 1. Use the GMT bundle installer (follow [this instruction](https://github.com/GenericMappingTools/gmt/blob/master/INSTALL.md#application-bundle))
-   (**recommended** for macOS >= 10.14 only; if you have an older macOS version consider upgrading first so you can use the installer) 
+   (**recommended** for macOS >= 10.14 only; if you have an older macOS version consider upgrading first so you can use the installer)
 2. Use homebrew (follow the ["Install instruction"](https://github.com/GenericMappingTools/gmt/blob/master/INSTALL.md#install-via-homebrew))
 3. Use the [conda package manager](https://conda.io/en/latest/) to install
    binaries for GMT and all dependencies


### PR DESCRIPTION
The Python 3.7 Anaconda is no longer available for Windows and macOS.
